### PR TITLE
docs: apply sentence case conventions to e2e test documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,17 @@
 # Claude Context for Forge E2E Tests
 
-## Current State
+## Current state
 
 Comprehensive end-to-end testing suite for the complete Forge platform. Tests validate API endpoints, authentication flows, frontend deployment, and system integration.
 
-## Technology Stack
+## Technology stack
 
 - **Jest** - Test framework and runner
 - **node-fetch** - HTTP client for API testing  
 - **Puppeteer** - Browser automation (UI tests)
 - **Node.js 16+** - Runtime environment
 
-## Project Structure
+## Project structure
 
 ```
 e2e-tests/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Comprehensive end-to-end tests for the complete Forge platform. These tests validate the entire application stack including API endpoints, authentication flow, frontend deployment, and system integration.
 
-## Quick Start
+## Quick start
 
 ```bash
 # Install dependencies
@@ -15,7 +15,7 @@ npm test
 npm run test:debug
 ```
 
-## Project Structure
+## Project structure
 
 ```
 e2e-tests/


### PR DESCRIPTION
## Summary
- Apply sentence case writing conventions to e2e test documentation
- Update section headers in README.md and CLAUDE.md
- Maintain consistency with project-wide style guidelines

## Changes
- "Quick Start" → "Quick start" 
- "Project Structure" → "Project structure"
- "Current State" → "Current state"
- "Technology Stack" → "Technology stack"

## Scope
- Documentation headers and section titles only
- Technical content and code examples unchanged
- Preserves all functionality and accuracy of testing guides

This ensures the e2e-tests repository follows the same sentence case convention as established across the entire hz-forge project.